### PR TITLE
fix: correct sucesfully typo to successfully (3 occurrences)

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -116,7 +116,7 @@ def create():
             # Write the minimal configuration to disk
             with open('wfpiconsole.ini', 'w') as config_file:
                 config.write(config_file)
-            print('\n  Sucesfully installed a minimal configuration file. Please edit')
+            print('\n  Successfully installed a minimal configuration file. Please edit')
             print('  this file manually to configure an advanced installation\n')
 
         # Unable to install minimal configuration

--- a/wfpiconsole.sh
+++ b/wfpiconsole.sh
@@ -800,7 +800,7 @@ process_complete() {
     # Display autostart-enable complete dialogue
         autostart-enable)
             printf "  ==================================================== \\n"
-            printf "  WeatherFlow PiConsole autostart sucesfully enabled   \\n"
+            printf "  WeatherFlow PiConsole autostart successfully enabled   \\n"
             printf "  Console will now start automatically at boot up      \\n"
             printf "  Starting console for current session. Please wait... \\n"
             printf "  ==================================================== \\n\\n"
@@ -808,7 +808,7 @@ process_complete() {
     # Display autostart-disable complete dialogue
         autostart-disable)
             printf "  =================================================== \\n"
-            printf "  WeatherFlow PiConsole autostart sucesfully disabled \\n"
+            printf "  WeatherFlow PiConsole autostart successfully disabled \\n"
             printf "  Use 'wfpiconsole stop' to halt current session      \\n"
             printf "  =================================================== \\n\\n"
     esac


### PR DESCRIPTION
## Summary
Corrects the typo 'sucesfully' → 'successfully' in 3 user-facing output messages.

## Changes
- `wfpiconsole.sh:803`: autostart enable confirmation message
- `wfpiconsole.sh:811`: autostart disable confirmation message  
- `lib/config.py:119`: installation success message

## Detection
Found via GitHub code search for `sucesfully` pattern in Python/Shell code strings.