### PR TITLE
fix: correct 'sucesfully' to 'successfully' typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The installation of the WeatherFlow PiConsole is fully automated, and can
 be started from the terminal with a single command. The automated installation
 should take no longer than 10 minutes.
 
-The automated installer assumes you have already sucesfully setup your Raspberry
+The automated installer assumes you have already successfully setup your Raspberry
 Pi and have installed Raspberry Pi OS with Desktop, or you ar running on a PC
 with Ubuntu 20.04 or later or Raspberry Pi OS installed. For a Raspberry Pi you
 should have also attached the touch screen, and have either a keyboard and mouse


### PR DESCRIPTION
## Description
Corrects a typo in the README.md file:

**Before:** "The automated installer assumes you have already sucesfully setup your Raspberry"
**After:** "The automated installer assumes you have already successfully setup your Raspberry"

## Files Changed
- README.md (line 67): Fixed typo in installation instructions

---
*This is a follow-up to issue #175 - this is a separate, simple typo fix in the same file.*